### PR TITLE
Fixed a fatal error when calling current after rewind

### DIFF
--- a/src/IteratorIterator.php
+++ b/src/IteratorIterator.php
@@ -29,7 +29,7 @@ class IteratorIterator implements \Iterator
      */
     public function current()
     {
-        return $this->currentIterator->current();
+        return $this->getCurrentIterator()->current();
     }
 
     /**


### PR DESCRIPTION
`rewind` sets the current iterator to `null`. Calling `current` before calling `next` or `valid` was then throwing a fatal error by calling a method on null because of the missing usage of the getter lazy-loading the current value
