### PR TITLE
Moved the test autoloading to autoload-dev

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,11 @@
     ],
     "autoload": {
         "psr-4": {
-            "AdrienBrault\\PagerfantaIterator\\": "src/",
+            "AdrienBrault\\PagerfantaIterator\\": "src/"
+        }
+    },
+    "autoload-dev": {
+        "psr-4": {
             "AdrienBrault\\PagerfantaIterator\\Tests\\": "tests/"
         }
     },


### PR DESCRIPTION
This avoids registering the test namespace in the autoloader when using the library as a dependency
