### PR TITLE
Upgrade phpunit and remove deprecated prophecy-phpunit dependency.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,8 +21,7 @@
         "pagerfanta/pagerfanta": "~1.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "~4.0",
-        "phpspec/prophecy-phpunit": "~1.0"
+        "phpunit/phpunit": "^4.8"
     },
     "extra": {
         "branch-alias": {

--- a/tests/PagerfantaIteratorTest.php
+++ b/tests/PagerfantaIteratorTest.php
@@ -5,9 +5,9 @@ namespace AdrienBrault\PagerfantaIterator\Tests;
 use AdrienBrault\PagerfantaIterator\IteratorIterator;
 use AdrienBrault\PagerfantaIterator\PagerfantaIterator;
 use Pagerfanta\Pagerfanta;
-use Prophecy\PhpUnit\ProphecyTestCase;
+use PHPUnit\Framework\TestCase;
 
-class PagerfantaIteratorTest extends ProphecyTestCase
+class PagerfantaIteratorTest extends TestCase
 {
     public function test()
     {


### PR DESCRIPTION
Since version 4.8, PHPUnit has included the Prophecy mocking framework integration. The `phpspec/prophecy-phpunit` is deprecated.